### PR TITLE
Refactored atoms

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,12 +538,15 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.2.0/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 <script src="http://d3js.org/d3.v3.min.js"></script>
-<script src="js/atoms/purge-atoms.js"></script>
-<script src="js/atoms/stackoverflow-atoms.js"></script>
-<script src="js/atoms/pinterest-atoms.js"></script>
-<script src="js/atoms/airbnb-atoms.js"></script>
-<script src="js/atoms/medium-atoms.js"></script>
-<script src="js/atoms/tachyons-atoms.js"></script>
+<script src="js/atoms/atoms.js"></script>
+<script>
+    createAtoms("purge-atoms", 1440, 600, 2016, "rgb(241,23,18)");
+    createAtoms("stackoverflow-atoms", 80, 80, 600, "rgb(254,122,21)");
+    createAtoms("pinterest-atoms", 80, 80, 1180, "rgb(189,8,28)");
+    createAtoms("airbnb-atoms", 80, 80, 356, "rgb(253,92,99)");
+    createAtoms("medium-atoms", 80, 80, 674, "rgb(47,184,139)");
+    createAtoms("tachyons-atoms", 80, 80, 40, "rgb(0,153,247)");
+</script>
 <script src="https://fb.me/react-15.0.1.js"></script>
 <script src="https://fb.me/react-dom-15.0.1.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser.min.js"></script>

--- a/js/atoms/atoms.js
+++ b/js/atoms/atoms.js
@@ -1,0 +1,39 @@
+/*
+	@id canvas ID
+	@w canvas width
+	@h canvas height
+	@qnt number of particles
+	@color particle fill color
+*/
+function createAtoms (id, w, h, qnt, color) {
+	var canvas = document.getElementById(id);
+	canvas.width = w;
+	canvas.height = h;
+	var ctx = canvas.getContext("2d");
+
+	var particles = d3.range(qnt).map(function(i) {
+	  return [Math.round(w*Math.random()), Math.round(h*Math.random())];
+	});
+
+	d3.timer(step);
+
+	function step () {
+	  ctx.fillStyle = "rgba(255,255,255,0.3)";
+	  ctx.fillRect(0, 0, w, h);
+	  ctx.fillStyle = color;
+
+	  particles.forEach(function(p) {
+	      p[0] += Math.round(2*Math.random()-1);
+	      p[1] += Math.round(2*Math.random()-1);
+	      if (p[0] < 0) p[0] = w;
+	      if (p[0] > w) p[0] = 0;
+	      if (p[1] < 0) p[1] = h;
+	      if (p[1] > h) p[1] = 0;
+	    drawPoints(p);
+	  });
+	};
+
+	function drawPoints (p) {
+	  ctx.fillRect(p[0],p[1],1,1);
+	};
+}


### PR DESCRIPTION
I find it's kind of strange to advocate for css optimization while having six js-files doing the exact same thing, so I refactored atoms into one function that takes several params (canvas id, width, height, number of particles and their color).

Additionally, I think d3.js is an overkill and would replace it with something like this:
```javascript
var particles = [];
while (qnt--) {
	particles.push([Math.round(w*Math.random()), Math.round(h*Math.random())]);
}
setInterval(step, D3_DEFAULT_INTERVAL);
```
But I found d3's usage in other files, so I've decided to leave it be.